### PR TITLE
Refactor DataStoreSettings for optional URL configuration and validation

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,7 @@ def test_datastore_settings(params, url):
     [
         {"scheme": "s3", "host": None, "path": "yo"},
         {"scheme": None, "host": "yeah/ye", "path": None},
+        {"url": "thisisnotavalidurl", "scheme": None, "host": None, "path": None},
         {"url": None, "scheme": None, "host": None, "path": None},
     ],
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,34 @@
+"""test for settings"""
+
+import pytest
+from pydantic import ValidationError
+
+from titiler.eopf.settings import DataStoreSettings
+
+
+@pytest.mark.parametrize(
+    "params,url",
+    [
+        ({"scheme": "s3", "host": "yeah/ye", "path": "yo"}, "s3://yeah/ye/yo"),
+        ({"scheme": "s3", "host": "yeah/ye", "path": None}, "s3://yeah/ye"),
+        ({"url": "s3://yeah/yo"}, "s3://yeah/yo"),
+    ],
+)
+def test_datastore_settings(params, url):
+    """Test DataStoreSettings."""
+    settings = DataStoreSettings(**params)
+    assert str(settings.url) == url
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"scheme": "s3", "host": None, "path": "yo"},
+        {"scheme": None, "host": "yeah/ye", "path": None},
+        {"url": None, "scheme": None, "host": None, "path": None},
+    ],
+)
+def test_datastore_settings_error(params):
+    """Missing URL or scheme/host."""
+    with pytest.raises(ValidationError):
+        DataStoreSettings(**params)

--- a/titiler/eopf/settings.py
+++ b/titiler/eopf/settings.py
@@ -1,6 +1,6 @@
 """API settings."""
 
-from pydantic import AnyUrl, ValidationInfo, field_validator, model_validator
+from pydantic import AnyUrl, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -49,20 +49,13 @@ class DataStoreSettings(BaseSettings):
             return v
 
         # Only build URL from components if url is not provided and scheme/host are available
-        if v is None and "scheme" in info.data and "host" in info.data:
+        if v is None and (info.data.get("scheme") and info.data.get("host")):
             return AnyUrl.build(
                 scheme=info.data["scheme"],
                 host=info.data["host"],
                 path=info.data.get("path", ""),
             )
-        
-        return v
 
-    @model_validator(mode="after")
-    def validate_config(self):
-        """Validate that either url is provided or scheme+host are provided."""
-        if not self.url and not (self.scheme and self.host):
-            raise ValueError(
-                "Either 'url' must be provided or both 'scheme' and 'host' must be provided"
-            )
-        return self
+        raise ValueError(
+            "Either 'url' must be provided or both 'scheme' and 'host' must be provided"
+        )


### PR DESCRIPTION
Update DataStoreSettings to allow optional scheme and host, and implement validation to ensure either a URL or both scheme and host are provided.