### PR TITLE
add optional cache_clear endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
         - types-attrs
         - pydantic~=2.0
         - types-redis
+        - types-cachetools

--- a/titiler/eopf/main.py
+++ b/titiler/eopf/main.py
@@ -8,7 +8,7 @@ import jinja2
 import rasterio
 import xarray
 import zarr
-from fastapi import FastAPI, Query
+from fastapi import Depends, FastAPI, Query
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates
@@ -29,6 +29,7 @@ from .extensions import (
     EOPFViewerExtension,
 )
 from .factory import TilerFactory
+from .reader import clear_cache
 from .settings import ApiSettings
 
 # Configure logging
@@ -155,6 +156,16 @@ app.add_middleware(
 if settings.debug:
     print(settings.debug)
     app.add_middleware(TotalTimeMiddleware)
+
+    # Cache Clearing Endpoint
+    @app.get(
+        "/_mgmt/collections/{collection_id}/items/{item_id}/clear",
+        include_in_schema=False,
+    )
+    def mgmt_clear_cache(src_path=Depends(DatasetPathParams)):
+        """clear_cache."""
+        clear_cache(src_path)
+        return {"message": "Cache cleared"}
 
 
 # Health Check Endpoints


### PR DESCRIPTION
closes #35 

This PR adds a `/_mgmt/collections/{collection_id}/items/{item_id}/clear` endpoint which will clear both the TTL local and Redis cache for a specific dataset 

The endpoint is only available in `debug` mode 