### PR TITLE
fix: update Python command for version checks to use specified pythonLocation

### DIFF
--- a/.github/workflows/docker-helm.yml
+++ b/.github/workflows/docker-helm.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Check Version
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          python -m pip install -e .
-          python -m pip install pyyaml
-          python .github/workflows/scripts/check_version.py
+          "$pythonLocation/bin/python" -m pip install -e .
+          "$pythonLocation/bin/python" -m pip install pyyaml
+          "$pythonLocation/bin/python" .github/workflows/scripts/check_version.py
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
Modify the version check script to utilize the specified pythonLocation for executing Python commands, ensuring consistency in the environment used for version checks.