### PR TITLE
fix: version-aware datatree cache (stale-on-append)

### DIFF
--- a/helm/charts/templates/deployment.yaml
+++ b/helm/charts/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
             # (EOPFCacheSettings.metadata_ttl).
             - name: TITILER_EOPF_CACHE_METADATA_TTL
               value: {{ .Values.cache.ttl.datasets | quote }}
+            # Store-version probe throttle; 0 disables probing (plain TTL mode).
+            - name: TITILER_EOPF_CACHE_VERSION_PROBE_TTL
+              value: {{ .Values.cache.versionProbeTtl | quote }}
             - name: TITILER_EOPF_CACHE_NAMESPACE
               value: {{ .Values.cache.namespace | quote }}
             {{- /* Redis Configuration */ -}}

--- a/helm/charts/templates/deployment.yaml
+++ b/helm/charts/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
               value: {{ .Values.cache.ttl.tiles | quote }}
             - name: TITILER_EOPF_CACHE_TTL_DATASETS
               value: {{ .Values.cache.ttl.datasets | quote }}
+            # TTL the GeoZarr reader actually reads for cached datatrees
+            # (EOPFCacheSettings.metadata_ttl).
+            - name: TITILER_EOPF_CACHE_METADATA_TTL
+              value: {{ .Values.cache.ttl.datasets | quote }}
             - name: TITILER_EOPF_CACHE_NAMESPACE
               value: {{ .Values.cache.namespace | quote }}
             {{- /* Redis Configuration */ -}}

--- a/helm/charts/values.yaml
+++ b/helm/charts/values.yaml
@@ -88,6 +88,11 @@ cache:
     tiles: 3600
     datasets: 1800  # 30 minutes
 
+  # Store-version probe (stale-on-append protection): TTL in seconds between
+  # HEAD probes of a store's root zarr.json. Set to 0 to disable probing and
+  # fall back to plain TTL caching (datasets expire after ttl.datasets).
+  versionProbeTtl: 5
+
   # Cache namespace and key generation
   namespace: "titiler-eopf"
   exclude_params:

--- a/helm/charts/values.yaml
+++ b/helm/charts/values.yaml
@@ -91,7 +91,7 @@ cache:
   # Store-version probe (stale-on-append protection): TTL in seconds between
   # HEAD probes of a store's root zarr.json. Set to 0 to disable probing and
   # fall back to plain TTL caching (datasets expire after ttl.datasets).
-  versionProbeTtl: 5
+  versionProbeTtl: 60
 
   # Cache namespace and key generation
   namespace: "titiler-eopf"

--- a/tests/test_open_dataset_cache.py
+++ b/tests/test_open_dataset_cache.py
@@ -99,6 +99,53 @@ def test_version_probe_failure_falls_back_to_src_path_key(
     assert not any("#" in k for k in keys)
 
 
+# --- Opt-out: version_probe_ttl=0 -> plain TTL behavior ---------------------
+
+
+def test_probe_disabled_skips_head_and_uses_plain_key(
+    geozarr_dataset, redis_client, monkeypatch
+):
+    """version_probe_ttl=0 never probes the store and caches under the bare src_path key."""
+    monkeypatch.setenv("TITILER_EOPF_CACHE_VERSION_PROBE_TTL", "0")
+    cache_settings.cache_clear()
+
+    def boom(src_path):
+        raise AssertionError("version probe must not run when version_probe_ttl=0")
+
+    monkeypatch.setattr(reader_mod, "_store_version", boom)
+    monkeypatch.setattr(reader_mod, "_store_version_cached", boom)
+    opens = _count_opens(monkeypatch)
+
+    open_dataset(geozarr_dataset)
+    open_dataset(geozarr_dataset)  # same TTL bucket -> served by the in-process memo
+
+    assert opens[0] == 1
+    norm = reader_mod._normalize_path(geozarr_dataset)
+    keys = _redis_keys(redis_client)
+    assert norm in keys
+    assert not any("#" in k for k in keys)
+
+
+def test_probe_disabled_memo_expires_after_metadata_ttl(
+    geozarr_dataset, redis_client, monkeypatch
+):
+    """With probing disabled, the in-process memo expires on `metadata_ttl` boundaries."""
+    monkeypatch.setenv("TITILER_EOPF_CACHE_VERSION_PROBE_TTL", "0")
+    monkeypatch.setenv("TITILER_EOPF_CACHE_METADATA_TTL", "300")
+    cache_settings.cache_clear()
+    opens = _count_opens(monkeypatch)
+
+    clock = [1000.0]
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: clock[0])
+
+    open_dataset(geozarr_dataset)  # read + cache (bucket N)
+    clock[0] += 301  # roll into bucket N+1
+    redis_client.flushall()  # simulate the Redis entry expiring on the same TTL
+    open_dataset(geozarr_dataset)
+
+    assert opens[0] == 2
+
+
 def test_store_version_returns_none_on_head_failure(monkeypatch):
     """A failed HEAD never raises; it degrades to None (so the cache falls back)."""
 

--- a/tests/test_open_dataset_cache.py
+++ b/tests/test_open_dataset_cache.py
@@ -1,0 +1,111 @@
+"""Tests for store-version-aware datatree caching in `open_dataset`.
+
+Covers the correctness behaviour added for issue #118: an append (changed
+store-version token) must produce a new cache key and trigger a fresh read,
+defeating both the Redis key and the in-process memo; a failed version probe
+must fall back to the bare `src_path` key.
+
+(The deterministic performance invariants for this caching live in
+`tests/test_open_dataset_cache_perf.py`.)
+"""
+
+import fakeredis
+import pytest
+
+import titiler.eopf.reader as reader_mod
+from titiler.eopf.reader import cache_settings, open_dataset
+
+
+def _reset_all() -> None:
+    open_dataset.cache_clear()
+    cache_settings.cache_clear()
+
+
+def _redis_keys(client) -> set[str]:
+    return {k.decode() for k in client.keys()}
+
+
+@pytest.fixture(autouse=True)
+def reset_caches():
+    """Reset every memo around each test (redis disabled by default env)."""
+    _reset_all()
+    yield
+    _reset_all()
+
+
+@pytest.fixture
+def redis_client(monkeypatch):
+    """Enable the redis cache path and inject an in-process fake client.
+
+    Uses `fakeredis.FakeStrictRedis` (not the TCP fake server) to avoid a
+    RESP2/RESP3 protocol mismatch, and patches the point where the reader builds
+    its client so the version-keyed get/set runs against the fake.
+    """
+    monkeypatch.setenv("TITILER_EOPF_CACHE_ENABLE", "TRUE")
+    monkeypatch.setenv("TITILER_EOPF_CACHE_REDIS_HOST", "localhost")
+    cache_settings.cache_clear()
+
+    fake = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(reader_mod.redis, "Redis", lambda **kwargs: fake)
+    yield fake
+
+
+def _count_opens(monkeypatch) -> list[int]:
+    """Patch `_open_from_store` to count real opens; returns a 1-element counter."""
+    counter = [0]
+    real_open = reader_mod._open_from_store
+
+    def counting(src_path: str):
+        counter[0] += 1
+        return real_open(src_path)
+
+    monkeypatch.setattr(reader_mod, "_open_from_store", counting)
+    return counter
+
+
+# --- Correctness -----------------------------------------------------------
+
+
+def test_append_changes_cache_key_and_rereads(
+    geozarr_dataset, redis_client, monkeypatch
+):
+    """A changed version token writes a new Redis key and re-reads the store."""
+    versions = iter(["v1", "v2"])
+    monkeypatch.setattr(reader_mod, "_store_version_cached", lambda src: next(versions))
+    opens = _count_opens(monkeypatch)
+
+    open_dataset(geozarr_dataset)  # v1 -> read + cache <path>#v1
+    open_dataset(geozarr_dataset)  # v2 -> miss -> read + cache <path>#v2
+
+    assert opens[0] == 2
+    norm = reader_mod._normalize_path(geozarr_dataset)
+    keys = _redis_keys(redis_client)
+    assert f"{norm}#v1" in keys
+    assert f"{norm}#v2" in keys
+
+
+def test_version_probe_failure_falls_back_to_src_path_key(
+    geozarr_dataset, redis_client, monkeypatch
+):
+    """When the version probe returns None, the bare src_path key is used and no error escapes."""
+    monkeypatch.setattr(reader_mod, "_store_version_cached", lambda src: None)
+
+    dt = open_dataset(geozarr_dataset)
+
+    assert dt is not None
+    norm = reader_mod._normalize_path(geozarr_dataset)
+    keys = _redis_keys(redis_client)
+    assert norm in keys
+    assert not any("#" in k for k in keys)
+
+
+def test_store_version_returns_none_on_head_failure(monkeypatch):
+    """A failed HEAD never raises; it degrades to None (so the cache falls back)."""
+
+    def boom(store, path):
+        raise FileNotFoundError("no such object")
+
+    monkeypatch.setattr(reader_mod.obstore, "head", boom)
+    reader_mod._get_store.cache_clear()
+
+    assert reader_mod._store_version("file:///tmp/does-not-exist.zarr") is None

--- a/tests/test_open_dataset_cache.py
+++ b/tests/test_open_dataset_cache.py
@@ -25,6 +25,13 @@ def _redis_keys(client) -> set[str]:
     return {k.decode() for k in client.keys()}
 
 
+def _assert_bare_src_path_key(redis_client, dataset_path: str) -> None:
+    """Assert the dataset was cached under the bare (un-versioned) src_path key."""
+    keys = _redis_keys(redis_client)
+    assert reader_mod._normalize_path(dataset_path) in keys
+    assert not any("#" in k for k in keys)
+
+
 @pytest.fixture(autouse=True)
 def reset_caches():
     """Reset every memo around each test (redis disabled by default env)."""
@@ -93,10 +100,7 @@ def test_version_probe_failure_falls_back_to_src_path_key(
     dt = open_dataset(geozarr_dataset)
 
     assert dt is not None
-    norm = reader_mod._normalize_path(geozarr_dataset)
-    keys = _redis_keys(redis_client)
-    assert norm in keys
-    assert not any("#" in k for k in keys)
+    _assert_bare_src_path_key(redis_client, geozarr_dataset)
 
 
 # --- Opt-out: version_probe_ttl=0 -> plain TTL behavior ---------------------
@@ -120,10 +124,7 @@ def test_probe_disabled_skips_head_and_uses_plain_key(
     open_dataset(geozarr_dataset)  # same TTL bucket -> served by the in-process memo
 
     assert opens[0] == 1
-    norm = reader_mod._normalize_path(geozarr_dataset)
-    keys = _redis_keys(redis_client)
-    assert norm in keys
-    assert not any("#" in k for k in keys)
+    _assert_bare_src_path_key(redis_client, geozarr_dataset)
 
 
 def test_probe_disabled_memo_expires_after_metadata_ttl(

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -167,36 +167,34 @@ def _open_dataset_cached(
     src_path: str, version: str | None, **kwargs: Any
 ) -> xarray.DataTree:
     """Open a datatree, cached in-process and in Redis under a version-aware key."""
-    cache_key = f"{src_path}#{version}" if version else src_path
-
     settings = cache_settings()
-    if settings.enable and settings.redis and settings.redis.host:
-        pool = RedisCache.get_instance(
+    if not (settings.enable and settings.redis and settings.redis.host):
+        return _open_from_store(src_path)
+
+    cache_key = f"{src_path}#{version}" if version else src_path
+    cache_client = redis.Redis(
+        connection_pool=RedisCache.get_instance(
             settings.redis.host,
             settings.redis.port,
             settings.redis.password,
         )
-        cache_client = redis.Redis(connection_pool=pool)
+    )
 
-        try:
-            if data_bytes := cache_client.get(cache_key):
-                logger.info(f"Cache - found dataset in Cache {cache_key}")
-                return pickle.loads(data_bytes)
-        except redis.RedisError as e:
-            # A cache outage must never break dataset opening.
-            logger.warning(
-                f"Cache - failed to read dataset from Cache {cache_key}: {e}"
-            )
+    try:
+        if data_bytes := cache_client.get(cache_key):
+            logger.info(f"Cache - found dataset in Cache {cache_key}")
+            return pickle.loads(data_bytes)
+    except redis.RedisError as e:
+        # A cache outage must never break dataset opening.
+        logger.warning(f"Cache - failed to read dataset from Cache {cache_key}: {e}")
 
-        dt = _open_from_store(src_path)
-        try:
-            logger.info(f"Cache - adding dataset in Cache {cache_key}")
-            cache_client.set(cache_key, pickle.dumps(dt), ex=settings.metadata_ttl)
-        except redis.RedisError as e:
-            logger.warning(f"Cache - failed to write dataset to Cache {cache_key}: {e}")
-        return dt
-
-    return _open_from_store(src_path)
+    dt = _open_from_store(src_path)
+    try:
+        logger.info(f"Cache - adding dataset in Cache {cache_key}")
+        cache_client.set(cache_key, pickle.dumps(dt), ex=settings.metadata_ttl)
+    except redis.RedisError as e:
+        logger.warning(f"Cache - failed to write dataset to Cache {cache_key}: {e}")
+    return dt
 
 
 def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -146,6 +146,21 @@ def _store_version_cached(src_path: str) -> str | None:
     return version
 
 
+def _cache_token(src_path: str) -> tuple[str | None, int | None]:
+    """Derive the `(version, lru_salt)` pair that keys the datatree caches.
+
+    Probe enabled: `(store version, None)` — an append rolls both the
+    in-process and Redis keys. Probe disabled (`version_probe_ttl <= 0`):
+    `(None, metadata_ttl-wide time bucket)` — plain TTL mode; the bucket
+    salts only the in-process memo so it expires on the `metadata_ttl`
+    cadence, matching the Redis entry's own TTL.
+    """
+    settings = cache_settings()
+    if settings.version_probe_ttl <= 0:
+        return None, int(time.monotonic() // max(settings.metadata_ttl, 1))
+    return _store_version_cached(src_path), None
+
+
 def _open_from_store(src_path: str) -> xarray.DataTree:
     """Open the datatree from the store (no caching)."""
     zarr_store = ObjectStore(store=_get_store(src_path), read_only=True)
@@ -223,14 +238,8 @@ def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
 
     """
     src_path = _normalize_path(src_path)
-    settings = cache_settings()
-
-    if settings.version_probe_ttl <= 0:
-        bucket = int(time.monotonic() // max(settings.metadata_ttl, 1))
-        return _open_dataset_cached(src_path, None, _ttl_bucket=bucket, **kwargs)
-
-    version = _store_version_cached(src_path)
-    return _open_dataset_cached(src_path, version, **kwargs)
+    version, ttl_bucket = _cache_token(src_path)
+    return _open_dataset_cached(src_path, version, _ttl_bucket=ttl_bucket, **kwargs)
 
 
 def _clear_open_dataset_caches() -> None:

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -7,9 +7,11 @@ import math
 import os
 import pickle
 import re
+import threading
+import time
 import warnings
 from collections.abc import Callable
-from functools import cache, cached_property, lru_cache
+from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -70,60 +72,102 @@ class MissingVariables(RioTilerError):
     """Missing Variables."""
 
 
-@cache
-def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
-    """Open Xarray dataset
+# Bound the in-process datatree memo. Unbounded caching + version-keying would
+# leak one datatree per append forever; LRU evicts the stale old versions first.
+DATASET_CACHE_MAXSIZE = 64
 
-    Args:
-        src_path (str): dataset path.
+# Throttle the store-version probe: src_path -> (monotonic_timestamp, version).
+_version_cache: dict[str, tuple[float, str | None]] = {}
+_version_cache_lock = threading.Lock()
 
-    Returns:
-        xarray.DataTree
 
+def _normalize_path(src_path: str) -> str:
+    """Resolve a scheme-less path to a `file://` URL; leave URLs untouched."""
+    if not urlparse(src_path).scheme:
+        return "file://" + str(Path(src_path).resolve())
+    return src_path
+
+
+@lru_cache(maxsize=DATASET_CACHE_MAXSIZE)
+def _get_store(src_path: str) -> Any:
+    """Build (and memoize) the obstore store for a dataset path.
+
+    Memoized so the S3/`AWS_PROFILE` branch does not rebuild the credential
+    provider / store on every request (the version probe runs per render).
     """
     parsed = urlparse(src_path)
-    if not parsed.scheme:
-        src_path = str(Path(src_path).resolve())
-        src_path = "file://" + src_path
+    aws_profile = os.environ.get("AWS_PROFILE")
+    if aws_profile and parsed.scheme == "s3" and HAS_BOTO3_PROVIDER:
+        from obstore.store import S3Store
 
-    def _open_dataset(src_path: str) -> xarray.DataTree:
-        # Check if AWS_PROFILE is set and we're dealing with an S3 URL
-        aws_profile = os.environ.get("AWS_PROFILE")
-        if aws_profile and parsed.scheme == "s3" and HAS_BOTO3_PROVIDER:
-            # Use Boto3CredentialProvider for AWS profile support
-            from obstore.store import S3Store
-
-            # Extract bucket and key from S3 URL
-            bucket = parsed.netloc
-            key = parsed.path.lstrip("/")
-
-            store = S3Store(
-                bucket,
-                credential_provider=Boto3CredentialProvider(),
-                region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
-                endpoint=os.environ.get("AWS_ENDPOINT_URL", None),
-                virtual_hosted_style_request=False,
-                prefix=key,
-            )
-
-            # Create the zarr store with the configured S3 store
-            zarr_store = ObjectStore(store=store, read_only=True)
-        else:
-            # Use the default obstore.store.from_url method
-            store = obstore.store.from_url(src_path)
-            zarr_store = ObjectStore(store=store, read_only=True)
-
-        return xarray.open_datatree(
-            zarr_store,
-            decode_times=True,
-            decode_coords="all",
-            create_default_indexes=False,
-            # By default xarray will try to load the consolidated metadata
-            # consolidated=True,
-            # See https://github.com/pydata/xarray/issues/11361
-            # use_zarr_fill_value_as_mask=True,
-            engine="zarr",
+        return S3Store(
+            parsed.netloc,
+            credential_provider=Boto3CredentialProvider(),
+            region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+            endpoint=os.environ.get("AWS_ENDPOINT_URL", None),
+            virtual_hosted_style_request=False,
+            prefix=parsed.path.lstrip("/"),
         )
+
+    return obstore.store.from_url(src_path)
+
+
+def _store_version(src_path: str) -> str | None:
+    """Token that changes when the store's consolidated metadata changes.
+
+    HEADs the root `zarr.json` (zarr v3 consolidated metadata) and returns its
+    ETag, falling back to `last_modified`. Returns None (and logs) on any
+    failure so a render never fails because the probe did.
+    """
+    try:
+        meta = obstore.head(_get_store(src_path), "zarr.json")
+        if etag := meta.get("e_tag"):
+            return etag
+        last_modified = meta.get("last_modified")
+        return last_modified.isoformat() if last_modified else None
+    except Exception as exc:  # noqa: BLE001 - never fail a render on a probe error
+        logger.warning(f"Cache - could not probe store version for {src_path}: {exc}")
+        return None
+
+
+def _store_version_cached(src_path: str) -> str | None:
+    """`_store_version` throttled to one HEAD per `version_probe_ttl` per path."""
+    ttl = cache_settings().version_probe_ttl
+    now = time.monotonic()
+    with _version_cache_lock:
+        cached = _version_cache.get(src_path)
+        if cached is not None and now - cached[0] < ttl:
+            return cached[1]
+
+    # HEAD outside the lock to avoid serializing requests on network I/O.
+    version = _store_version(src_path)
+    with _version_cache_lock:
+        _version_cache[src_path] = (now, version)
+    return version
+
+
+def _open_from_store(src_path: str) -> xarray.DataTree:
+    """Open the datatree from the store (no caching)."""
+    zarr_store = ObjectStore(store=_get_store(src_path), read_only=True)
+    return xarray.open_datatree(
+        zarr_store,
+        decode_times=True,
+        decode_coords="all",
+        create_default_indexes=False,
+        # By default xarray will try to load the consolidated metadata
+        # consolidated=True,
+        # See https://github.com/pydata/xarray/issues/11361
+        # use_zarr_fill_value_as_mask=True,
+        engine="zarr",
+    )
+
+
+@lru_cache(maxsize=DATASET_CACHE_MAXSIZE)
+def _open_dataset_cached(
+    src_path: str, version: str | None, **kwargs: Any
+) -> xarray.DataTree:
+    """Open a datatree, cached in-process and in Redis under a version-aware key."""
+    cache_key = f"{src_path}#{version}" if version else src_path
 
     settings = cache_settings()
     if settings.enable and settings.redis and settings.redis.host:
@@ -134,28 +178,56 @@ def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
         )
         cache_client = redis.Redis(connection_pool=pool)
 
-        dt = None
         try:
-            if data_bytes := cache_client.get(src_path):
-                logger.info(f"Cache - found dataset in Cache {src_path}")
-                dt = pickle.loads(data_bytes)
+            if data_bytes := cache_client.get(cache_key):
+                logger.info(f"Cache - found dataset in Cache {cache_key}")
+                return pickle.loads(data_bytes)
         except redis.RedisError as e:
             # A cache outage must never break dataset opening.
-            logger.warning(f"Cache - failed to read dataset from Cache {src_path}: {e}")
+            logger.warning(
+                f"Cache - failed to read dataset from Cache {cache_key}: {e}"
+            )
 
-        if dt is None:
-            dt = _open_dataset(src_path)
-            try:
-                logger.info(f"Cache - adding dataset in Cache {src_path}")
-                cache_client.set(src_path, pickle.dumps(dt), ex=settings.metadata_ttl)
-            except redis.RedisError as e:
-                logger.warning(
-                    f"Cache - failed to write dataset to Cache {src_path}: {e}"
-                )
-    else:
-        dt = _open_dataset(src_path)
+        dt = _open_from_store(src_path)
+        try:
+            logger.info(f"Cache - adding dataset in Cache {cache_key}")
+            cache_client.set(cache_key, pickle.dumps(dt), ex=settings.metadata_ttl)
+        except redis.RedisError as e:
+            logger.warning(f"Cache - failed to write dataset to Cache {cache_key}: {e}")
+        return dt
 
-    return dt
+    return _open_from_store(src_path)
+
+
+def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
+    """Open Xarray dataset, keyed on the store's current version token.
+
+    An append rewrites the store's root `zarr.json`, changing its version token,
+    which produces a new cache key (in-process and in Redis) and a fresh read —
+    so the newest slice becomes visible without admin cache invalidation.
+
+    Args:
+        src_path (str): dataset path.
+
+    Returns:
+        xarray.DataTree
+
+    """
+    src_path = _normalize_path(src_path)
+    version = _store_version_cached(src_path)
+    return _open_dataset_cached(src_path, version, **kwargs)
+
+
+def _clear_open_dataset_caches() -> None:
+    """Clear every datatree-related memo (datatree, store, version probe)."""
+    _open_dataset_cached.cache_clear()
+    _get_store.cache_clear()
+    with _version_cache_lock:
+        _version_cache.clear()
+
+
+# Preserve the public `open_dataset.cache_clear()` contract used by benchmarks.
+open_dataset.cache_clear = _clear_open_dataset_caches  # type: ignore[attr-defined]
 
 
 def get_multiscale_level(

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -164,9 +164,15 @@ def _open_from_store(src_path: str) -> xarray.DataTree:
 
 @lru_cache(maxsize=DATASET_CACHE_MAXSIZE)
 def _open_dataset_cached(
-    src_path: str, version: str | None, **kwargs: Any
+    src_path: str, version: str | None, _ttl_bucket: int | None = None, **kwargs: Any
 ) -> xarray.DataTree:
-    """Open a datatree, cached in-process and in Redis under a version-aware key."""
+    """Open a datatree, cached in-process and in Redis under a version-aware key.
+
+    `_ttl_bucket` only participates in the lru_cache key: when version probing
+    is disabled it rolls over every `metadata_ttl` seconds so the in-process
+    memo expires. It is process-local (monotonic-based) and must never leak
+    into the Redis key, which is shared across replicas.
+    """
     settings = cache_settings()
     if not (settings.enable and settings.redis and settings.redis.host):
         return _open_from_store(src_path)
@@ -204,6 +210,11 @@ def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
     which produces a new cache key (in-process and in Redis) and a fresh read —
     so the newest slice becomes visible without admin cache invalidation.
 
+    Setting `version_probe_ttl=0` opts out of version probing entirely: no HEAD
+    requests are made and caching degrades to plain TTL behavior — the Redis
+    entry expires after `metadata_ttl` and the in-process memo is keyed on a
+    `metadata_ttl`-wide time bucket so it expires on the same cadence.
+
     Args:
         src_path (str): dataset path.
 
@@ -212,6 +223,12 @@ def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
 
     """
     src_path = _normalize_path(src_path)
+    settings = cache_settings()
+
+    if settings.version_probe_ttl <= 0:
+        bucket = int(time.monotonic() // max(settings.metadata_ttl, 1))
+        return _open_dataset_cached(src_path, None, _ttl_bucket=bucket, **kwargs)
+
     version = _store_version_cached(src_path)
     return _open_dataset_cached(src_path, version, **kwargs)
 

--- a/titiler/eopf/settings.py
+++ b/titiler/eopf/settings.py
@@ -79,7 +79,10 @@ class EOPFCacheSettings(BaseCacheSettings):
     namespace: str = "titiler-eopf"
     default_ttl: int = 3600  # 1 hour default TTL
     tile_ttl: int = 86400  # 24 hours for tiles
-    metadata_ttl: int = 300  # 5 minutes for metadata
+    metadata_ttl: int = 300  # 5 minutes for metadata (incl. cached datatrees)
+    # TTL (seconds) for the store-version probe; bounds both the staleness window
+    # after an append and the per-request HEAD rate (see GeoZarrReader caching).
+    version_probe_ttl: int = 5
 
     # Parameter exclusion for cache keys
     exclude_params: list[str] = ["format", "callback", "buffer"]

--- a/titiler/eopf/settings.py
+++ b/titiler/eopf/settings.py
@@ -82,6 +82,8 @@ class EOPFCacheSettings(BaseCacheSettings):
     metadata_ttl: int = 300  # 5 minutes for metadata (incl. cached datatrees)
     # TTL (seconds) for the store-version probe; bounds both the staleness window
     # after an append and the per-request HEAD rate (see GeoZarrReader caching).
+    # Set to 0 to opt out of version probing entirely: no HEAD requests are made
+    # and cached datatrees simply expire after `metadata_ttl` (plain TTL mode).
     version_probe_ttl: int = 5
 
     # Parameter exclusion for cache keys

--- a/titiler/eopf/settings.py
+++ b/titiler/eopf/settings.py
@@ -81,10 +81,12 @@ class EOPFCacheSettings(BaseCacheSettings):
     tile_ttl: int = 86400  # 24 hours for tiles
     metadata_ttl: int = 300  # 5 minutes for metadata (incl. cached datatrees)
     # TTL (seconds) for the store-version probe; bounds both the staleness window
-    # after an append and the per-request HEAD rate (see GeoZarrReader caching).
+    # after an append and the per-process HEAD rate (see GeoZarrReader caching).
+    # 60s keeps HEAD traffic negligible while bounding post-append staleness to
+    # a minute — plenty for stores that append on a cadence of days.
     # Set to 0 to opt out of version probing entirely: no HEAD requests are made
     # and cached datatrees simply expire after `metadata_ttl` (plain TTL mode).
-    version_probe_ttl: int = 5
+    version_probe_ttl: int = 60
 
     # Parameter exclusion for cache keys
     exclude_params: list[str] = ["format", "callback", "buffer"]


### PR DESCRIPTION
Closes the cache half of #118 (the datetime `sel` fix is in a separate PR).

Split out of #119 per review — this PR is the irreducible correctness fix plus the performance guards that keep the per-render version probe cheap. The deterministic perf-invariant test suite ships separately (stacked PR) so this one stays focused.

## Problem
Datatree opens were cached keyed only by `src_path` — in-process via `functools.cache` and in Redis — so an append to an existing store was invisible until TTL and flapped 500/400 across ~40 replicas with no working invalidation (`/cache/invalidate` SCAN 504s).

## Fix
Fold a store-version token into the cache key: HEAD the root `zarr.json` (zarr v3 consolidated metadata) and key on `{src_path}#{etag}`, in both the in-process LRU and Redis. An append rewrites `zarr.json` → ETag changes → new key → fresh read; every replica computes the same key; stale keys self-expire. A failed probe falls back to the bare `src_path` key (a render never fails because the probe did). This also defeats the in-process `functools.cache` pinning — the stickiest stale layer per replica.

## Performance (kept here on purpose — the probe runs per render)
- `_get_store` is memoized → no `Boto3CredentialProvider`/`S3Store` rebuild per request.
- `_store_version` is throttled to one HEAD per `version_probe_ttl` per path, collapsing the per-tile HEAD storm a viewport would cause.
- the in-process memo is a bounded `lru_cache(maxsize=64)` instead of unbounded `functools.cache`, so version-keying can't leak one datatree per append.

## Config
- `version_probe_ttl` added to `EOPFCacheSettings`.
- Helm now also emits `TITILER_EOPF_CACHE_METADATA_TTL` (the datatree TTL the reader actually reads) from `cache.ttl.datasets`, closing the config mismatch the issue flagged.

## Tests
- Append → new key + reread; probe-failure → `src_path` fallback; HEAD-failure → None.
- `uv run pytest` → 103 passed; pre-commit (ruff, ruff-format, isort, mypy) clean.

Refs #118 (cache half; close the issue once the sel PR also lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
