### PR TITLE
fix: graceful 400 on datetime sel against a stale int64 axis

### DIFF
--- a/tests/benchmarks/benchmarks.py
+++ b/tests/benchmarks/benchmarks.py
@@ -22,16 +22,6 @@ def geozarr_benchmark():
         shutil.rmtree(geozarr_path)
 
 
-@pytest.fixture
-def geozarr_3d_benchmark():
-    """GeoZarr dataset path with a time dimension (for `sel` benchmarks)."""
-    geozarr_path = os.path.join(os.path.dirname(__file__), "geozarr_3d.zarr")
-    create_geozarr_fixture(geozarr_path, version="v1", with_time=True)
-    yield geozarr_path
-    if os.path.exists(geozarr_path):
-        shutil.rmtree(geozarr_path)
-
-
 @pytest.mark.benchmark(min_rounds=50)
 @patch("titiler.eopf.reader.cache_settings")
 def test_open(cache_settings, geozarr_benchmark, benchmark):
@@ -110,29 +100,6 @@ def test_tile(cache_settings, geozarr_benchmark, benchmark):
                     "/measurements/reflectance:b03",
                     "/measurements/reflectance:b02",
                 ],
-            )
-
-    _ = benchmark(_tile)
-
-
-@pytest.mark.benchmark(min_rounds=50)
-@patch("titiler.eopf.reader.cache_settings")
-def test_tile_sel(cache_settings, geozarr_3d_benchmark, benchmark):
-    """Benchmark a tile read with a datetime `sel` (guards the sel-cast path)."""
-    cache_settings.side_effect = lambda: EOPFCacheSettings(enable=False)
-
-    benchmark.name = "GeoZarrReader-Tile-Sel"
-    benchmark.fullname = "GeoZarrReader-Tile-Sel"
-
-    def _tile():
-        open_dataset.cache_clear()
-        with GeoZarrReader(geozarr_3d_benchmark) as src:
-            return src.tile(
-                554,
-                395,
-                10,
-                variables=["/measurements/reflectance:b02"],
-                sel=["time=2022-01-02T00:00:00.000000000"],
             )
 
     _ = benchmark(_tile)

--- a/tests/benchmarks/benchmarks.py
+++ b/tests/benchmarks/benchmarks.py
@@ -22,6 +22,16 @@ def geozarr_benchmark():
         shutil.rmtree(geozarr_path)
 
 
+@pytest.fixture
+def geozarr_3d_benchmark():
+    """GeoZarr dataset path with a time dimension (for `sel` benchmarks)."""
+    geozarr_path = os.path.join(os.path.dirname(__file__), "geozarr_3d.zarr")
+    create_geozarr_fixture(geozarr_path, version="v1", with_time=True)
+    yield geozarr_path
+    if os.path.exists(geozarr_path):
+        shutil.rmtree(geozarr_path)
+
+
 @pytest.mark.benchmark(min_rounds=50)
 @patch("titiler.eopf.reader.cache_settings")
 def test_open(cache_settings, geozarr_benchmark, benchmark):
@@ -100,6 +110,29 @@ def test_tile(cache_settings, geozarr_benchmark, benchmark):
                     "/measurements/reflectance:b03",
                     "/measurements/reflectance:b02",
                 ],
+            )
+
+    _ = benchmark(_tile)
+
+
+@pytest.mark.benchmark(min_rounds=50)
+@patch("titiler.eopf.reader.cache_settings")
+def test_tile_sel(cache_settings, geozarr_3d_benchmark, benchmark):
+    """Benchmark a tile read with a datetime `sel` (guards the sel-cast path)."""
+    cache_settings.side_effect = lambda: EOPFCacheSettings(enable=False)
+
+    benchmark.name = "GeoZarrReader-Tile-Sel"
+    benchmark.fullname = "GeoZarrReader-Tile-Sel"
+
+    def _tile():
+        open_dataset.cache_clear()
+        with GeoZarrReader(geozarr_3d_benchmark) as src:
+            return src.tile(
+                554,
+                395,
+                10,
+                variables=["/measurements/reflectance:b02"],
+                sel=["time=2022-01-02T00:00:00.000000000"],
             )
 
     _ = benchmark(_tile)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -5,6 +5,7 @@ import pytest
 import xarray
 from rio_tiler.errors import ExpressionMixingWarning
 
+from titiler.core.errors import BadRequestError
 from titiler.eopf.reader import GeoZarrReader, MissingVariables
 
 
@@ -639,7 +640,6 @@ def test_sel_datetime_happy_path(geozarr_3d_dataset):
 
 def test_sel_on_int64_axis_raises_bad_request(geozarr_3d_dataset):
     """A datetime `sel` against a (stale) int64 time axis degrades to 4xx, not 500."""
-    from titiler.core.errors import BadRequestError
 
     def _cast_time_to_int64(ds: xarray.Dataset) -> xarray.Dataset:
         if "time" in ds.coords:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -624,3 +624,35 @@ def test_scale_offset(geozarr_so):
         assert img.array.shape == (2, 64, 128)
         assert img.array.dtype == numpy.float32
         assert img.array.mask[0, 0, 0]
+
+
+def test_sel_datetime_happy_path(geozarr_3d_dataset):
+    """A datetime64 time axis selects by an ISO datetime string (regression)."""
+    with GeoZarrReader(geozarr_3d_dataset) as src:
+        da = src._get_variable(
+            "/measurements/reflectance",
+            "b02",
+            sel=["time=2022-01-02T00:00:00.000000000"],
+        )
+        assert "time" not in da.dims
+
+
+def test_sel_on_int64_axis_raises_bad_request(geozarr_3d_dataset):
+    """A datetime `sel` against a (stale) int64 time axis degrades to 4xx, not 500."""
+    from titiler.core.errors import BadRequestError
+
+    def _cast_time_to_int64(ds: xarray.Dataset) -> xarray.Dataset:
+        if "time" in ds.coords:
+            return ds.assign_coords(time=ds["time"].astype("int64"))
+        return ds
+
+    src = GeoZarrReader(geozarr_3d_dataset)
+    # Simulate a legacy/stale store whose `time` axis is int64, not datetime64.
+    src.datatree = src.datatree.map_over_datasets(_cast_time_to_int64)
+
+    with pytest.raises(BadRequestError):
+        src._get_variable(
+            "/measurements/reflectance",
+            "b02",
+            sel=["time=2022-01-02T00:00:00.000000000"],
+        )

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -33,6 +33,7 @@ from rio_tiler.types import BBox
 from rio_tiler.utils import _get_width_height, _missing_size
 from zarr.storage import ObjectStore
 
+from titiler.core.errors import BadRequestError
 from titiler.xarray.io import _parse_dsl
 
 from .cache import RedisCache
@@ -857,7 +858,15 @@ class GeoZarrReader(BaseReader):
             # TODO: add more casting
             # cast string to dtype of the dimension
             if da[dimension].dtype != "O":
-                values = [da[dimension].dtype.type(v) for v in values]
+                try:
+                    values = [da[dimension].dtype.type(v) for v in values]
+                except (ValueError, TypeError) as exc:
+                    # e.g. a datetime `sel` against a stale int64 axis:
+                    # degrade to 4xx instead of escaping as a 500.
+                    raise BadRequestError(
+                        f"Cannot select {dimension}={values!r} on a "
+                        f"{da[dimension].dtype} axis"
+                    ) from exc
 
             da = da.sel(
                 {dimension: values[0] if len(values) < 2 else values},


### PR DESCRIPTION
Closes the `sel` half of #118 (the stale-cache fix is a separate PR).

## Problem
A `sel` value was cast with `da[dim].dtype.type(v)`. Against a stale/legacy int64 `time` axis, `np.int64("2026-06-08T17:38:52")` raised `ValueError` that escaped as HTTP 500.

## Fix
Wrap the cast in `try/except` and raise `BadRequestError` (already mapped to 400). No datetime branch is added: `dtype.type` is already `np.datetime64` for a datetime axis, so the happy path is unchanged.

## Tests
- int64 axis + ISO `sel` → `BadRequestError`; datetime64 happy path preserved.
- Added a sel-tile benchmark guarding the cast path.
- `uv run pytest` → 102 passed; pre-commit clean.

Split out of #119 per review.
Refs #118 (sel half; close the issue once the cache PR also lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
