### PR TITLE
test: deterministic perf invariants for the datatree cache

### DIFF
--- a/tests/benchmarks/benchmarks.py
+++ b/tests/benchmarks/benchmarks.py
@@ -41,6 +41,29 @@ def test_open(cache_settings, geozarr_benchmark, benchmark):
 
 @pytest.mark.benchmark(min_rounds=50)
 @patch("titiler.eopf.reader.cache_settings")
+def test_open_cached(cache_settings, geozarr_benchmark, benchmark):
+    """Benchmark warm open_dataset: version-probe memo + in-process datatree memo hit.
+
+    This is the hot path most requests take; it would regress visibly if the
+    version-probe throttle were removed (a HEAD on every call).
+    """
+    cache_settings.side_effect = lambda: EOPFCacheSettings(enable=False)
+
+    benchmark.name = "GeoZarrReader-Open-Cached"
+    benchmark.fullname = "GeoZarrReader-Open-Cached"
+
+    open_dataset.cache_clear()
+    open_dataset(geozarr_benchmark)  # warm every memo once
+
+    def _open_cached():
+        with GeoZarrReader(geozarr_benchmark):
+            pass
+
+    _ = benchmark(_open_cached)
+
+
+@pytest.mark.benchmark(min_rounds=50)
+@patch("titiler.eopf.reader.cache_settings")
 def test_info(cache_settings, geozarr_benchmark, benchmark):
     """Benchmark GeoZarrReader.info method."""
     cache_settings.side_effect = lambda: EOPFCacheSettings(enable=False)

--- a/tests/test_open_dataset_cache_perf.py
+++ b/tests/test_open_dataset_cache_perf.py
@@ -1,0 +1,105 @@
+"""Deterministic performance invariants for the version-aware datatree cache.
+
+These assert exact side-effect *counts* (HEADs, store builds, datatree opens),
+not wall-clock timing, so they fail loudly the moment a perf guard regresses —
+the probe throttle, the `_get_store` memo, or the bounded in-process memo —
+regardless of machine speed. They complement the wall-clock benchmark suite.
+
+Correctness behaviour for the same cache lives in `tests/test_open_dataset_cache.py`.
+"""
+
+import pytest
+
+import titiler.eopf.reader as reader_mod
+from titiler.eopf.reader import cache_settings, open_dataset
+
+
+def _reset_all() -> None:
+    open_dataset.cache_clear()
+    cache_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_caches():
+    """Reset every memo around each test (redis disabled by default env)."""
+    _reset_all()
+    yield
+    _reset_all()
+
+
+def _count_opens(monkeypatch) -> list[int]:
+    """Patch `_open_from_store` to count real opens; returns a 1-element counter."""
+    counter = [0]
+    real_open = reader_mod._open_from_store
+
+    def counting(src_path: str):
+        counter[0] += 1
+        return real_open(src_path)
+
+    monkeypatch.setattr(reader_mod, "_open_from_store", counting)
+    return counter
+
+
+def test_version_probe_throttled_within_ttl(geozarr_dataset, monkeypatch):
+    """N opens within version_probe_ttl issue a single HEAD; a re-probe occurs after the window."""
+    head_calls = [0]
+    real_head = reader_mod.obstore.head
+
+    def counting_head(store, path):
+        head_calls[0] += 1
+        return real_head(store, path)
+
+    monkeypatch.setattr(reader_mod.obstore, "head", counting_head)
+    monkeypatch.setenv("TITILER_EOPF_CACHE_VERSION_PROBE_TTL", "5")
+    cache_settings.cache_clear()
+
+    clock = [1000.0]
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: clock[0])
+    open_dataset.cache_clear()
+
+    for _ in range(5):
+        open_dataset(geozarr_dataset)
+    assert head_calls[0] == 1
+
+    clock[0] = 1010.0  # advance beyond the 5s window
+    open_dataset(geozarr_dataset)
+    assert head_calls[0] == 2
+
+
+def test_store_built_once_across_opens(geozarr_dataset, monkeypatch):
+    """The obstore store is constructed once per path (no per-request rebuild)."""
+    build_calls = [0]
+    real_from_url = reader_mod.obstore.store.from_url
+
+    def counting_from_url(url, *args, **kwargs):
+        build_calls[0] += 1
+        return real_from_url(url, *args, **kwargs)
+
+    monkeypatch.setattr(reader_mod.obstore.store, "from_url", counting_from_url)
+    open_dataset.cache_clear()
+
+    for _ in range(4):
+        open_dataset(geozarr_dataset)
+
+    assert build_calls[0] == 1
+
+
+def test_no_reopen_on_stable_token_reopen_on_change(geozarr_dataset, monkeypatch):
+    """A stable token reuses the in-process tree; a changed token defeats the memo."""
+    monkeypatch.setattr(reader_mod, "_store_version_cached", lambda src: "stable")
+    opens = _count_opens(monkeypatch)
+    open_dataset.cache_clear()
+
+    for _ in range(3):
+        open_dataset(geozarr_dataset)
+    assert opens[0] == 1
+
+    monkeypatch.setattr(reader_mod, "_store_version_cached", lambda src: "changed")
+    open_dataset(geozarr_dataset)
+    assert opens[0] == 2
+
+
+def test_dataset_memo_is_bounded():
+    """The in-process datatree memo is bounded (regression guard vs unbounded @cache)."""
+    info = reader_mod._open_dataset_cached.cache_info()
+    assert info.maxsize is not None and info.maxsize > 0


### PR DESCRIPTION
The "optional hardening" split out of #119 per review: extra test/CI rigor for the version-aware cache (#122). **No runtime code.**

Wall-clock benchmarks are too noisy to catch "1 HEAD became 30". These pin the cache's perf invariants by counting side effects with spies:
- no HEAD storm: N opens within `version_probe_ttl` → one `obstore.head`; re-probes after the window (monkeypatched clock).
- store built once: N opens → `_get_store`'s constructor runs once.
- no redundant reopen: stable token → one open; changed token → exactly one more.
- bounded memo: `_open_dataset_cached` is an `lru_cache` with positive maxsize.

Also adds a warm-open benchmark (`test_open_cached`) so the CI github-action-benchmark job alerts if the probe throttle/memo regress.

`uv run pytest` → 107 passed; benchmarks collect; pre-commit clean.

Refs #118. **Stacked on #122** — this PR targets the `fix/issue-118-stale-cache` branch; retarget to `main` (`gh pr edit <num> --base main`) once #122 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
