### PR TITLE
fix(cache): align Redis settings and fix Helm env-var wiring for cache TTLs

### DIFF
--- a/helm/charts/CACHE_CONFIG.md
+++ b/helm/charts/CACHE_CONFIG.md
@@ -89,7 +89,8 @@ The chart automatically generates the following environment variables based on c
 ### Cache Control
 - `TITILER_EOPF_CACHE_ENABLE`: "true" when cache is enabled
 - `TITILER_EOPF_CACHE_BACKEND`: Backend type (redis/s3/s3-redis)  
-- `TITILER_EOPF_CACHE_TTL_DEFAULT`: Default TTL in seconds
+- `TITILER_EOPF_CACHE_DEFAULT_TTL`: Default TTL in seconds
+- `TITILER_EOPF_CACHE_TILE_TTL`: Tile cache TTL in seconds
 - `TITILER_EOPF_CACHE_NAMESPACE`: Cache key namespace
 
 ### Redis Configuration

--- a/helm/charts/README.md
+++ b/helm/charts/README.md
@@ -48,7 +48,6 @@ See [CACHE_CONFIG.md](CACHE_CONFIG.md) for detailed configuration guide.
 | `cache.backend` | Cache backend: `redis`, `s3`, or `s3-redis` | `redis` |
 | `cache.ttl.default` | Default TTL in seconds | `3600` |
 | `cache.ttl.tiles` | Tile cache TTL in seconds | `3600` |
-| `cache.ttl.datasets` | Dataset cache TTL in seconds | `1800` |
 | `cache.namespace` | Cache key namespace | `titiler-eopf` |
 
 ### Redis Cache Configuration

--- a/helm/charts/examples/cache-external-redis-values.yaml
+++ b/helm/charts/examples/cache-external-redis-values.yaml
@@ -21,7 +21,6 @@ cache:
   ttl:
     default: 1800  # 30 minutes
     tiles: 3600    # 1 hour
-    datasets: 900  # 15 minutes
   
   namespace: "staging-cache"
   exclude_params:

--- a/helm/charts/examples/cache-redis-values.yaml
+++ b/helm/charts/examples/cache-redis-values.yaml
@@ -14,7 +14,6 @@ cache:
   ttl:
     default: 3600
     tiles: 3600
-    datasets: 1800
   
   namespace: "dev-cache"
   

--- a/helm/charts/examples/cache-s3-redis-values.yaml
+++ b/helm/charts/examples/cache-s3-redis-values.yaml
@@ -31,8 +31,7 @@ cache:
   # Cache settings for production
   ttl:
     default: 7200  # 2 hours
-    tiles: 14400   # 4 hours  
-    datasets: 3600 # 1 hour
+    tiles: 14400   # 4 hours
   
   namespace: "prod-cache"
   

--- a/helm/charts/templates/deployment.yaml
+++ b/helm/charts/templates/deployment.yaml
@@ -44,12 +44,10 @@ spec:
               value: "true"
             - name: TITILER_EOPF_CACHE_BACKEND
               value: {{ .Values.cache.backend | quote }}
-            - name: TITILER_EOPF_CACHE_TTL_DEFAULT
+            - name: TITILER_EOPF_CACHE_DEFAULT_TTL
               value: {{ .Values.cache.ttl.default | quote }}
-            - name: TITILER_EOPF_CACHE_TTL_TILES
+            - name: TITILER_EOPF_CACHE_TILE_TTL
               value: {{ .Values.cache.ttl.tiles | quote }}
-            - name: TITILER_EOPF_CACHE_TTL_DATASETS
-              value: {{ .Values.cache.ttl.datasets | quote }}
             - name: TITILER_EOPF_CACHE_NAMESPACE
               value: {{ .Values.cache.namespace | quote }}
             {{- /* Redis Configuration */ -}}
@@ -59,7 +57,7 @@ spec:
             - name: TITILER_EOPF_CACHE_REDIS_PORT
               value: {{ include "titiler-eopf.cache.redis.port" . | quote }}
               {{- if .Values.cache.redis.external.database }}
-            - name: TITILER_EOPF_CACHE_REDIS_DATABASE
+            - name: TITILER_EOPF_CACHE_REDIS_DB
               value: {{ .Values.cache.redis.external.database | quote }}
               {{- end }}
               {{- /* Redis Authentication - External Redis */ -}}

--- a/helm/charts/values.yaml
+++ b/helm/charts/values.yaml
@@ -86,7 +86,6 @@ cache:
   ttl:
     default: 3600  # 1 hour
     tiles: 3600
-    datasets: 1800  # 30 minutes
 
   # Cache namespace and key generation
   namespace: "titiler-eopf"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,8 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
-from titiler.eopf.settings import DataStoreSettings
+from titiler.cache import CacheRedisSettings
+from titiler.eopf.settings import CacheSettings, DataStoreSettings
 
 
 class IsolatedDataStoreSettings(DataStoreSettings):
@@ -54,3 +55,38 @@ def test_datastore_settings_error(params, monkeypatch):
     monkeypatch.delenv("TITILER_EOPF_STORE_PATH", raising=False)
     with pytest.raises(ValidationError):
         IsolatedDataStoreSettings(**params)
+
+
+class IsolatedCacheSettings(CacheSettings):
+    """Reader cache settings without .env loading."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_EOPF_CACHE_REDIS_", env_file=None, extra="ignore"
+    )
+
+
+class IsolatedCacheRedisSettings(CacheRedisSettings):
+    """Tile-cache Redis settings without .env loading."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_EOPF_CACHE_REDIS_", env_file=None, extra="ignore"
+    )
+
+
+def test_reader_and_tile_cache_redis_settings_aligned(monkeypatch):
+    """Reader cache and tile cache resolve the same Redis connection config.
+
+    Both read the ``TITILER_EOPF_CACHE_REDIS_`` prefix, so host/port/db must
+    resolve identically — otherwise the two caches could target different
+    Redis servers or databases.
+    """
+    monkeypatch.setenv("TITILER_EOPF_CACHE_REDIS_HOST", "redis.example")
+    monkeypatch.setenv("TITILER_EOPF_CACHE_REDIS_PORT", "6380")
+    monkeypatch.setenv("TITILER_EOPF_CACHE_REDIS_DB", "3")
+
+    reader_cache = IsolatedCacheSettings()
+    tile_cache = IsolatedCacheRedisSettings()
+
+    assert reader_cache.host == tile_cache.host == "redis.example"
+    assert reader_cache.port == tile_cache.port == 6380
+    assert reader_cache.db == tile_cache.db == 3

--- a/titiler/eopf/cache.py
+++ b/titiler/eopf/cache.py
@@ -18,7 +18,7 @@ class RedisCache:
 
     @classmethod
     def get_instance(
-        cls, host: str, port: int, password: SecretStr | None
+        cls, host: str, port: int, password: SecretStr | None, db: int = 0
     ) -> redis.ConnectionPool:
         """Get the redis connection pool."""
         assert redis, "Redis package needs to be installed to use Redis Cache"
@@ -27,6 +27,6 @@ class RedisCache:
                 host=host,
                 port=port,
                 password=password.get_secret_value() if password else None,
-                db=0,
+                db=db,
             )
         return cls._instance

--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -131,6 +131,7 @@ def open_dataset(src_path: str, **kwargs: Any) -> xarray.DataTree:
             cache_settings().host,  # type: ignore
             cache_settings().port,
             cache_settings().password,
+            cache_settings().db,
         )
         cache_client = redis.Redis(connection_pool=pool)
         if data_bytes := cache_client.get(src_path):

--- a/titiler/eopf/settings.py
+++ b/titiler/eopf/settings.py
@@ -66,15 +66,19 @@ class DataStoreSettings(BaseSettings):
 
 
 class CacheSettings(BaseSettings):
-    """Legacy Redis Cache Settings - replaced by TiTiler Cache Extension.
+    """Redis settings for the reader dataset cache.
 
-    This class maintains backward compatibility with existing EOPF cache settings
-    while providing access to the new comprehensive cache system.
+    Shares the ``TITILER_EOPF_CACHE_REDIS_`` env prefix (host/port/password/db)
+    with the titiler.cache extension's ``CacheRedisSettings`` so the reader's
+    DataTree cache and the response/tile cache always target the same Redis
+    server and database. Enabled independently via
+    ``TITILER_EOPF_CACHE_REDIS_ENABLE``.
     """
 
     host: str | None = None
     port: int = 6379
     password: SecretStr | None = None
+    db: int = 0
     enable: bool = False
 
     model_config = SettingsConfigDict(


### PR DESCRIPTION
Cache env vars in the Helm chart didn't match the pydantic field names, so configured values were silently ignored (app ran on defaults). This aligns them.

**Changes**
- `deployment.yaml`: `TTL_DEFAULT→DEFAULT_TTL`, `TTL_TILES→TILE_TTL`, `REDIS_DATABASE→REDIS_DB`
- Removed orphaned `cache.ttl.datasets` (no consumer) from chart/values/README/examples
- Pass Redis `db` through `RedisCache.get_instance` (was hardcoded `0`)
- Added a test for `db` resolution

No runtime change today (`db` defaults to 0). After release, prod tile TTL applies as configured (jumps from default 86400 to `cache.ttl.tiles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)