### PR TITLE
ci: scan the Docker image with Trivy before publishing it

### DIFF
--- a/.github/workflows/docker-helm.yml
+++ b/.github/workflows/docker-helm.yml
@@ -25,11 +25,6 @@ jobs:
       actions: write # Persist Docker layer cache for docker/build-push-action (type=gha).
       security-events: write # Upload Trivy SARIF to the GitHub Security tab.
 
-    env:
-      # Local-only tag: the scan must not depend on the order of the tags that
-      # docker/metadata-action emits, and this tag is never pushed.
-      SCAN_IMAGE: titiler-eopf:scan
-
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -67,26 +62,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      # Build locally first so Trivy can scan the exact image before it is
-      # published. The push step below rebuilds from the same GHA layer cache,
-      # so it is a cache hit rather than a second full build.
-      - name: Build Docker image (local, for scanning)
+      # Build once, into the local daemon. Nothing is published until Trivy has
+      # cleared this exact image: the push step below uploads these very tags,
+      # it does not rebuild. The Dockerfile pins no versions (floating
+      # python:3.12, apt upgrade, pip --upgrade), so a rebuild could resolve
+      # different packages than the ones that were scanned.
+      - name: Build Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile
           push: false
           load: true
-          tags: ${{ env.SCAN_IMAGE }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Scanned by image ID rather than by tag: every tag above points at this
+      # ID, and it does not depend on the order metadata-action emits tags in.
       - name: Scan image with Trivy (SARIF CRITICAL/HIGH, incl. unfixed)
         id: trivy-sarif-critical-high
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.SCAN_IMAGE }}
+          image-ref: ${{ steps.build.outputs.imageid }}
           format: sarif
           output: trivy-results-critical-high.sarif
           exit-code: '0'
@@ -96,7 +96,7 @@ jobs:
       - name: Fail on fixable CRITICAL vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.SCAN_IMAGE }}
+          image-ref: ${{ steps.build.outputs.imageid }}
           format: table
           exit-code: '1'
           ignore-unfixed: true
@@ -106,7 +106,7 @@ jobs:
       - name: Warn on fixable HIGH vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.SCAN_IMAGE }}
+          image-ref: ${{ steps.build.outputs.imageid }}
           format: table
           exit-code: '0'
           ignore-unfixed: true
@@ -114,14 +114,15 @@ jobs:
           severity: HIGH
 
       - name: Push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+        env:
+          META_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$META_TAGS" | while read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Pushing $tag"
+            docker push "$tag"
+          done
 
       # Fork PRs get a read-only GITHUB_TOKEN, so the upload would fail there.
       - name: Upload Trivy SARIF (CRITICAL/HIGH) to GitHub Security tab

--- a/.github/workflows/docker-helm.yml
+++ b/.github/workflows/docker-helm.yml
@@ -17,8 +17,19 @@ permissions:
 
 jobs:
   docker:
-    
+
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone repo and supply Docker build context.
+      packages: write # Push the image to ghcr.io.
+      actions: write # Persist Docker layer cache for docker/build-push-action (type=gha).
+      security-events: write # Upload Trivy SARIF to the GitHub Security tab.
+
+    env:
+      # Local-only tag: the scan must not depend on the order of the tags that
+      # docker/metadata-action emits, and this tag is never pushed.
+      SCAN_IMAGE: titiler-eopf:scan
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,7 +67,53 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build and push Docker image
+      # Build locally first so Trivy can scan the exact image before it is
+      # published. The push step below rebuilds from the same GHA layer cache,
+      # so it is a cache hit rather than a second full build.
+      - name: Build Docker image (local, for scanning)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.SCAN_IMAGE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy (SARIF CRITICAL/HIGH, incl. unfixed)
+        id: trivy-sarif-critical-high
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.SCAN_IMAGE }}
+          format: sarif
+          output: trivy-results-critical-high.sarif
+          exit-code: '0'
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
+      - name: Fail on fixable CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.SCAN_IMAGE }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL
+
+      - name: Warn on fixable HIGH vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.SCAN_IMAGE }}
+          format: table
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: HIGH
+
+      - name: Push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -64,6 +121,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+
+      # Fork PRs get a read-only GITHUB_TOKEN, so the upload would fail there.
+      - name: Upload Trivy SARIF (CRITICAL/HIGH) to GitHub Security tab
+        if: steps.trivy-sarif-critical-high.outcome == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: trivy-results-critical-high.sarif
+          category: trivy-critical-high
 
   helm:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,22 @@ uv run pre-commit install
 # If needed, you can run pre-commit script manually 
 uv run pre-commit run --all-files 
 ```
+
+**container image scanning**
+
+The `Docker and Helm` workflow scans the image with [Trivy](https://trivy.dev)
+before pushing it, and fails on any *fixable* `CRITICAL` vulnerability. To
+reproduce that gate locally:
+
+```bash
+docker build -t titiler-eopf:scan .
+
+# Same gate as CI: non-zero exit on a fixable CRITICAL
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:0.69.3 image \
+  --ignore-unfixed --vuln-type os,library --severity CRITICAL --exit-code 1 \
+  titiler-eopf:scan
+```
+
+Drop `--ignore-unfixed` to also see vulnerabilities with no upstream fix yet;
+those are reported to the GitHub Security tab but never block a build.


### PR DESCRIPTION
Mirrors the Trivy setup from `EOPF-Explorer/data-pipeline`: the `docker` job builds the image into the local daemon, scans it, and only then pushes — fail on fixable `CRITICAL`, warn on fixable `HIGH`, and upload a `CRITICAL`/`HIGH` SARIF report (unfixed included) to the Security tab. The push uploads the tags built in the scan step rather than rebuilding, so what is published is the image that passed the gate. Verified locally against the current image: 0 fixable `CRITICAL` (gate passes today) and 2 fixable `HIGH` (`msgpack` 1.1.2→1.2.1, `setuptools` 70.3.0→78.1.1).

For reviewers: the second commit reworks the first after review feedback — worth reading the diff commit-by-commit. The original built twice and trusted a GHA cache hit to make the pushed image identical to the scanned one; since the Dockerfile pins nothing (floating `python:3.12`, `apt upgrade -y`, `pip install --upgrade`), a cache miss would have published unscanned package versions. Two consequences of building once with `load: true`: `docker push` does not attach the provenance attestation `build-push-action` adds on `push: true` (unused in this repo), and the build is single-arch — already the case, the job sets up QEMU but never sets `platforms`. Separately, the `python:3.12` base carries ~17 unfixed `CRITICAL` and ~114 unfixed `HIGH` CVEs that will appear in the Security tab as informational; none originate in our layers, and `python:3.12-slim` would cut that to 4 and 8. That base change is not in this PR.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: Claude Code ported the data-pipeline Trivy steps, applied the review feedback, and drafted the CONTRIBUTING note; I reviewed the workflow diff and confirmed the gate locally with `docker build` + `trivy image --ignore-unfixed --severity CRITICAL --exit-code 1`.
