### PR TITLE
fix: select correct overview when tilesize=None in endpoint

### DIFF
--- a/titiler/eopf/reader.py
+++ b/titiler/eopf/reader.py
@@ -1062,7 +1062,7 @@ class GeoZarrReader(BaseReader):
         *args: Any,
         variables: list[str] | None = None,
         expression: str | None = None,
-        tilesize: int = 256,
+        tilesize: int | None = None,
         sel: list[str] | None = None,
         **kwargs: Any,
     ) -> ImageData:
@@ -1087,6 +1087,8 @@ class GeoZarrReader(BaseReader):
                 "`variables` must be passed via `expression` or `variables` options."
             )
 
+        matrix = self.tms.matrix(tile_z)
+
         for gv in variables:
             group, variable = gv.split(":") if ":" in gv else ("/", gv)
             with GeoArrayReader(
@@ -1100,8 +1102,8 @@ class GeoZarrReader(BaseReader):
                         tile_bounds[2],
                         tile_bounds[3],
                     ),
-                    height=tilesize,
-                    width=tilesize,
+                    height=tilesize or matrix.tileHeight,
+                    width=tilesize or matrix.tileWidth,
                     dst_crs=dst_crs,
                 ),
                 tms=self.tms,


### PR DESCRIPTION
in titiler endpoint we have `tilesize=None` by default 

https://github.com/developmentseed/titiler/blob/0c7c8429634c27abaecbb7b56d95fee72066cacd/src/titiler/core/titiler/core/factory.py#L897-L900

then in titiler-eopf the `GeoZarrReader.tile()` will try to select the overviews with `width=None, height=None` https://github.com/EOPF-Explorer/titiler-eopf/blob/641ff4cdc8425cc31fd86206c3515b375e1b9412/titiler/eopf/reader.py#L1103-L1104

With this PR, when tilesize=None we will then use the TMS's matrix tilesize. Same will be done for each arrays https://github.com/cogeotiff/rio-tiler/blob/200a4e8e074ffe0b0d88f63d1fb36bbed13d1934/rio_tiler/experimental/xarray.py#L370-L371