### PR TITLE
fix(openeo): install titiler-openeo's oidc extra so httpx reaches production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,33 @@ jobs:
           name: ${{ matrix.python-version }}
           fail_ci_if_error: false
 
+  # The `tests` job above runs `uv sync`, which installs the dev group. The Docker
+  # image does not. A runtime dependency that only reaches the tests through the
+  # dev group is therefore missing in production while CI stays green -- which is
+  # how the 0.12.0 candidate shipped an openEO app that could not import.
+  runtime-imports:
+    name: production dependency closure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.9.*"
+          enable-cache: false
+          python-version: ${{ env.LATEST_PY_VERSION }}
+
+      # Same flags as the Dockerfile, so this closure is what production gets.
+      - name: Install dependencies without the dev group
+        run: |
+          uv sync --frozen --no-dev --extra server --extra cache --extra openeo --no-install-project
+          uv pip install --no-deps .
+
+      - name: Import every deployed app
+        run: |
+          uv run --no-sync python .github/workflows/scripts/check_runtime_imports.py
+
   benchmark:
     if: github.repository == 'EOPF-Explorer/titiler-eopf'
     needs: [tests]

--- a/.github/workflows/scripts/check_runtime_imports.py
+++ b/.github/workflows/scripts/check_runtime_imports.py
@@ -1,0 +1,72 @@
+"""Import every deployed ASGI app using only the production dependency closure.
+
+The Docker image installs `--no-dev --extra server --extra cache --extra openeo`,
+so anything that reaches the runtime *only* through the dev group is missing in
+production. That is not hypothetical: titiler-openeo 0.18 moved `httpx` behind its
+`oidc` extra, `bump-my-version` kept pulling httpx into the dev group, and the
+openEO app crashed at import in staging while CI stayed green.
+
+Run this in an environment synced WITHOUT the dev group. Nothing here touches the
+network at import time; the settings below are placeholders that only need to be
+well-formed enough for each module body to run to the end.
+"""
+
+import os
+import sys
+
+REPO = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
+)
+
+os.environ.setdefault("TITILER_EOPF_STAC_API_URL", "https://example.invalid/stac")
+os.environ.setdefault("TITILER_OPENEO_STAC_API_URL", "https://example.invalid/stac")
+os.environ.setdefault(
+    "TITILER_OPENEO_STORE_URL", os.path.join(REPO, "services", "eopf-explorer.json")
+)
+# Exercise the cache backend. It is off by default, and while it is off the
+# `cache` extra (redis, boto3) is never imported -- so a dependency dropped there
+# would slip past this check exactly as httpx did. s3-redis is what production
+# runs and it pulls both. Constructing the backends opens no connection.
+os.environ.setdefault("TITILER_EOPF_CACHE_ENABLE", "true")
+os.environ.setdefault("TITILER_EOPF_CACHE_BACKEND", "s3-redis")
+os.environ.setdefault("TITILER_EOPF_CACHE_REDIS_HOST", "localhost")
+os.environ.setdefault("TITILER_EOPF_CACHE_REDIS_PORT", "6379")
+os.environ.setdefault("TITILER_EOPF_CACHE_S3_BUCKET", "ci-not-a-real-bucket")
+os.environ.setdefault("TITILER_EOPF_CACHE_S3_REGION", "de")
+
+# Our deployments run OIDC, and the OIDC branch is the one carrying optional-
+# dependency guards, so exercise it rather than the "basic" default.
+os.environ.setdefault("TITILER_OPENEO_AUTH_METHOD", "oidc")
+os.environ.setdefault("TITILER_OPENEO_AUTH_OIDC_CLIENT_ID", "ci")
+os.environ.setdefault(
+    "TITILER_OPENEO_AUTH_OIDC_WK_URL",
+    "https://example.invalid/.well-known/openid-configuration",
+)
+os.environ.setdefault(
+    "TITILER_OPENEO_AUTH_OIDC_REDIRECT_URL", "https://example.invalid/"
+)
+
+APPS = ["titiler.eopf.main", "titiler.eopf.openeo.main"]
+
+failures = []
+for name in APPS:
+    try:
+        __import__(name)
+    # Deliberately broad: the failure this guards against was an AssertionError
+    # from an optional-dependency check, not an ImportError.
+    except Exception as exc:
+        failures.append(name)
+        print(f"FAIL {name}\n     {type(exc).__name__}: {exc}", file=sys.stderr)
+    else:
+        print(f"ok   {name}")
+
+if failures:
+    print(
+        f"\n{len(failures)} deployed app(s) cannot be imported from the production "
+        "dependency closure. A runtime dependency is probably reaching the tests "
+        "through the dev group only.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"\nall {len(APPS)} deployed apps import cleanly without the dev group")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 openeo = [
-    "titiler-openeo>=0.18,<0.19",
+    "titiler-openeo[oidc]>=0.18,<0.19",
     "openeo",
     "duckdb",
     "sqlalchemy>=2.0.0",
@@ -66,7 +66,7 @@ dev = [
     "pre-commit",
     "bump-my-version",
     "boto3",
-    "titiler-openeo>=0.18,<0.19",
+    "titiler-openeo[oidc]>=0.18,<0.19",
     "ipython",
     "ipykernel",
     "jupyter-client",

--- a/uv.lock
+++ b/uv.lock
@@ -2536,7 +2536,7 @@ openeo = [
     { name = "openeo" },
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
-    { name = "titiler-openeo" },
+    { name = "titiler-openeo", extra = ["oidc"] },
 ]
 server = [
     { name = "gunicorn" },
@@ -2562,7 +2562,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "sqlalchemy" },
-    { name = "titiler-openeo" },
+    { name = "titiler-openeo", extra = ["oidc"] },
 ]
 performance = [
     { name = "pytest-benchmark" },
@@ -2586,7 +2586,7 @@ requires-dist = [
     { name = "starlette-cramjam", specifier = ">=0.4,<1.0" },
     { name = "titiler-core", specifier = ">=2.1,<3.0" },
     { name = "titiler-extensions", specifier = ">=2.1,<3.0" },
-    { name = "titiler-openeo", marker = "extra == 'openeo'", specifier = ">=0.18,<0.19" },
+    { name = "titiler-openeo", extras = ["oidc"], marker = "extra == 'openeo'", specifier = ">=0.18,<0.19" },
     { name = "titiler-stacapi", specifier = ">=2.0,<3.0" },
     { name = "titiler-xarray", specifier = ">=2.1,<3.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'" },
@@ -2612,7 +2612,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
-    { name = "titiler-openeo", specifier = ">=0.18,<0.19" },
+    { name = "titiler-openeo", extras = ["oidc"], specifier = ">=0.18,<0.19" },
 ]
 performance = [{ name = "pytest-benchmark" }]
 
@@ -2657,6 +2657,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/ff51e4a87b3988823bc478e4cbe50f0c6662ae2394ccbe56edb312b89ecb/titiler_openeo-0.18.0.tar.gz", hash = "sha256:539670d669465f6b1cdd99e3aa17e81891076808aca1947b5263291fa2fbd44d", size = 300363 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/cc/804b396917228eb9ae94afb52ac33f9ff0e94ad06ba32111117ac1d4a5a0/titiler_openeo-0.18.0-py3-none-any.whl", hash = "sha256:24deffc3bcf1ce599b9f7e4c3615419f1e52319c1c24810921e6a076d698e3a3", size = 385860 },
+]
+
+[package.optional-dependencies]
+oidc = [
+    { name = "cryptography" },
+    { name = "httpx" },
 ]
 
 [[package]]


### PR DESCRIPTION
titiler-openeo 0.18 moved `httpx` behind its `oidc` extra, so `titiler.eopf.openeo.main` no longer imports — every `titiler-openeo-staging` pod on the 0.12.0 candidate (`pr-159`) CrashLoopBackOffs with `AssertionError: httpx module must be installed to use OIDC Auth method`. Any deployment with `auth.method: "oidc"` is affected, production included.

The new `runtime-imports` CI job installs exactly what the Dockerfile installs (`--no-dev`, same extras) and imports both deployed apps; `tests` runs `uv sync` *with* the dev group, where bump-my-version was quietly supplying httpx. Confirmed to fail on the old pin and pass on the new one.

Caveat: `uv.lock` is edited in place rather than regenerated — `uv lock` here also drops pywin32's `sys_platform == 'win32'` marker and some riscv64/graalpy wheels, unrelated to this fix. `uv sync --frozen` accepts the result and installs httpx 0.28.1.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: Claude Code diagnosed the crash from the staging pod logs, traced it to the extra, made the change and wrote the CI guard; I reviewed the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #161 
